### PR TITLE
[BACK] 게시글 기능 구현 및 테스트, 회원 api 까지 구현

### DIFF
--- a/back/src/main/java/com/duder/api/fixture/MemberFixture.java
+++ b/back/src/main/java/com/duder/api/fixture/MemberFixture.java
@@ -1,0 +1,9 @@
+package com.duder.api.fixture;
+
+import com.duder.api.member.domain.Member;
+import com.duder.api.security.service.ProviderType;
+
+public class MemberFixture {
+    public static Member MEMBER1 = new Member(1L, "12345", ProviderType.KAKAO,
+            "김진오", "nickname", "www.naver.com", "rlawlsdh1127@naver.com");
+}

--- a/back/src/main/java/com/duder/api/fixture/PostFixture.java
+++ b/back/src/main/java/com/duder/api/fixture/PostFixture.java
@@ -1,0 +1,30 @@
+package com.duder.api.fixture;
+
+import com.duder.api.post.domain.Photo;
+import com.duder.api.post.domain.Post;
+import com.duder.api.post.request.PostEnrollRequest;
+import com.duder.api.post.request.PostUpdateRequest;
+import com.duder.api.post.service.CoordinateUtil;
+
+import java.util.Arrays;
+
+public class PostFixture {
+
+    public static final Long POST_ID = 1L;
+    public static final Long MEMBER_ID = 1L;
+
+    public final static Post POST1 = new Post(POST_ID, 37.1234, 126.1234, Photo.of("www.abc.com", "www.def.com"),
+            "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.1234, 126.1234));
+
+    public final static Post POST2 = new Post(37.3456, 126.1324, Photo.of("www.abc.com", "www.def.com"),
+            "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.3456, 126.1324));
+
+    public final static Post POST3 = new Post(37.4567, 126.2345, Photo.of("www.abc.com", "www.def.com"),
+            "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.4567, 126.2345));
+
+    public final static PostEnrollRequest 상수맛집_게시글_요청 = new PostEnrollRequest(37.1234, 126.1234,
+            Arrays.asList("www.abc.com", "www.def.com"), "상수맛집 추천좀요");
+
+    public final static PostUpdateRequest 게시글_수정_요청 = new PostUpdateRequest("상수 맛집 추천좀");
+
+}

--- a/back/src/main/java/com/duder/api/member/application/MemberService.java
+++ b/back/src/main/java/com/duder/api/member/application/MemberService.java
@@ -1,0 +1,26 @@
+package com.duder.api.member.application;
+
+import com.duder.api.member.domain.Member;
+import com.duder.api.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+    public final String MEMBER_NOT_FOUND_EXCEPTION = "회원이 존재하지 않습니다.";
+
+    @Transactional
+    public Member updateMemberNickname(Member member, String nickname) {
+        member.updateNickname(nickname);
+        return member;
+    }
+
+    public Member findById(Long memberId){
+        return memberRepository.findMemberById(memberId).orElseThrow(
+                () -> new IllegalArgumentException(MEMBER_NOT_FOUND_EXCEPTION));
+    }
+}

--- a/back/src/main/java/com/duder/api/member/domain/Member.java
+++ b/back/src/main/java/com/duder/api/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.duder.api.member.domain;
 
 import com.duder.api.common.BaseEntity;
 import com.duder.api.security.service.ProviderType;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,7 +38,15 @@ public class Member extends BaseEntity {
 
     private String email;
 
-    public Member(String providerId, ProviderType providerType, String name, String nickname, String profile, String email) {
+    public Member(String name, String nickname, String profile, String email) {
+        this.name = name;
+        this.nickname = nickname;
+        this.profile = profile;
+        this.email = email;
+    }
+
+    public Member(Long id, String providerId, ProviderType providerType, String name, String nickname, String profile, String email) {
+        this.id = id;
         this.providerId = providerId;
         this.providerType = providerType;
         this.name = name;
@@ -46,15 +55,15 @@ public class Member extends BaseEntity {
         this.email = email;
     }
 
-    public Member(String name, String nickname, String profile, String email) {
-        this.name = name;
-        this.nickname = nickname;
-        this.profile = profile;
-        this.email = email;
+    public Member(String providerId, ProviderType providerType, String name, String nickname, String profile, String email) {
+        this(null, providerId, providerType, name, nickname, profile, email);
     }
 
     public void updateNickname(String nickname){
         this.nickname = nickname;
     }
 
+    public boolean isNotSameId(Member member) {
+        return !id.equals(member.getId());
+    }
 }

--- a/back/src/main/java/com/duder/api/member/domain/MemberRepository.java
+++ b/back/src/main/java/com/duder/api/member/domain/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByProviderId(String providerId);
+    Optional<Member> findMemberById(Long memberId);
 }

--- a/back/src/main/java/com/duder/api/member/presentation/MemberController.java
+++ b/back/src/main/java/com/duder/api/member/presentation/MemberController.java
@@ -1,0 +1,41 @@
+package com.duder.api.member.presentation;
+
+import com.duder.api.form.ApiForm;
+import com.duder.api.member.application.MemberService;
+import com.duder.api.member.domain.Member;
+import com.duder.api.member.response.MemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import static com.duder.api.form.ApiForm.*;
+
+@RequestMapping("/api/me")
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+    public final String SUCCESS_FIND_MEMBER = "성공적으로 회원을 찾았습니다.";
+    public final String SUCCESS_UPDATE_MEMBER = "회원 정보를 성공적으로 수정했습니다.";
+
+    @GetMapping
+    public ApiForm<?> findMemberById(@AuthenticationPrincipal OAuth2User oAuth2User){
+        try {
+            return succeed(MemberResponse.of(oAuth2User.getAttribute("member")), SUCCESS_FIND_MEMBER);
+        }catch (IllegalArgumentException e){
+            return fail(e.getMessage());
+        }
+    }
+
+    @PutMapping("/update")
+    public ApiForm<?> updateMemberNickname(@AuthenticationPrincipal OAuth2User oAuth2User, @RequestParam String nickname){
+        try {
+            return succeed(MemberResponse.of(memberService.updateMemberNickname(
+                    oAuth2User.getAttribute("member"), nickname)), SUCCESS_UPDATE_MEMBER);
+        }catch (IllegalArgumentException e){
+            return fail(e.getMessage());
+        }
+    }
+}

--- a/back/src/main/java/com/duder/api/post/domain/Photo.java
+++ b/back/src/main/java/com/duder/api/post/domain/Photo.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Getter @NoArgsConstructor
@@ -18,6 +19,10 @@ public class Photo {
 
     public Photo(List<String> photoUrls) {
         this.photoUrl = photoUrls;
+    }
+
+    public static Photo of(String ...photoUrl){
+        return new Photo(Arrays.asList(photoUrl));
     }
 
 }

--- a/back/src/main/java/com/duder/api/post/domain/Post.java
+++ b/back/src/main/java/com/duder/api/post/domain/Post.java
@@ -2,6 +2,7 @@ package com.duder.api.post.domain;
 
 import com.duder.api.common.BaseEntity;
 import com.duder.api.member.domain.Member;
+import com.duder.api.post.request.PostUpdateRequest;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +20,8 @@ import javax.persistence.*;
  * cellValue : 게시글의 cell 값
  */
 
- @Getter @NoArgsConstructor
+ @Getter
+ @NoArgsConstructor
  @Entity
 public class Post extends BaseEntity {
 
@@ -53,4 +55,17 @@ public class Post extends BaseEntity {
         this.cellValue = cellValue;
     }
 
+    public Post(Long id, double latitude, double longitude, Photo photo, String content, Member member, Integer cellValue) {
+        this.id = id;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.photo = photo;
+        this.content = content;
+        this.member = member;
+        this.cellValue = cellValue;
+    }
+
+    public void update(PostUpdateRequest postUpdateRequest){
+        this.content = postUpdateRequest.getContent();
+    }
 }

--- a/back/src/main/java/com/duder/api/post/presentation/PostController.java
+++ b/back/src/main/java/com/duder/api/post/presentation/PostController.java
@@ -1,8 +1,8 @@
 package com.duder.api.post.presentation;
 
 import com.duder.api.form.ApiForm;
-import com.duder.api.member.domain.Member;
 import com.duder.api.post.request.PostEnrollRequest;
+import com.duder.api.post.request.PostUpdateRequest;
 import com.duder.api.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,21 +18,24 @@ import static com.duder.api.form.ApiForm.succeed;
 public class PostController {
 
     private final PostService postService;
+    public final String SUCCESS_ENROLL_POST = "게시글 등록에 성공했습니다.";
+    public final String SUCCESS_FIND_POST = "게시글을 조회에 성공했습니다.";
+    public final String SUCCESS_UPDATE_POST = "게시글을 수정했습니다.";
+    public final String SUCCESS_DELETE_POST = "게시글을 삭제했습니다.";
 
     @PostMapping("/enroll")
     public ApiForm<?> enroll(@AuthenticationPrincipal OAuth2User oAuth2User, PostEnrollRequest request){
         try {
-            return succeed(postService.enroll(oAuth2User.getAttribute("member"), request), "게시글 등록에 성공했습니다.");
+            return succeed(postService.enroll(oAuth2User.getAttribute("member"), request), SUCCESS_ENROLL_POST);
         } catch (Exception e) {
             return fail(e.getMessage());
         }
     }
 
     @GetMapping("/{postId}")
-    public ApiForm<?> findPostById(@AuthenticationPrincipal OAuth2User oAuth2User, @PathVariable Long postId)
-            throws IllegalArgumentException{
+    public ApiForm<?> findPostById(@PathVariable Long postId) {
         try {
-            return succeed(postService.findPostById(postId), "게시글을 찾았습니다.");
+            return succeed(postService.findPostById(postId), SUCCESS_FIND_POST);
         }catch (IllegalArgumentException e){
             return fail(e.getMessage());
         }
@@ -40,9 +43,27 @@ public class PostController {
 
     @GetMapping("/get")
     public ApiForm<?> findPostsByDistance(@RequestParam("latitude") double latitude, @RequestParam("longitude") double longitude,
-                                          @RequestParam("distance") int distance) throws IllegalArgumentException{
+                                          @RequestParam("distance") int distance){
         try{
-            return succeed(postService.findPostsByDistance(latitude, longitude, distance), "게시글을 찾았습니다.");
+            return succeed(postService.findPostsByDistance(latitude, longitude, distance), SUCCESS_FIND_POST);
+        }catch (IllegalArgumentException e){
+            return fail(e.getMessage());
+        }
+    }
+
+    @PutMapping("/update/{postId}")
+    public ApiForm<?> updatePost(@PathVariable Long postId, @RequestBody PostUpdateRequest postUpdateRequest){
+        try {
+            return succeed(postService.updatePost(postId, postUpdateRequest), SUCCESS_UPDATE_POST);
+        }catch (IllegalArgumentException e){
+            return fail(e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/delete/{postId}")
+    public ApiForm<?> deletePost(@AuthenticationPrincipal OAuth2User oAuth2User, @PathVariable Long postId){
+        try{
+            return succeed(postService.deletePost(oAuth2User.getAttribute("member"), postId), SUCCESS_DELETE_POST);
         }catch (IllegalArgumentException e){
             return fail(e.getMessage());
         }

--- a/back/src/main/java/com/duder/api/post/request/PostUpdateRequest.java
+++ b/back/src/main/java/com/duder/api/post/request/PostUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.duder.api.post.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostUpdateRequest {
+    String content;
+}

--- a/back/src/main/java/com/duder/api/security/util/JwtTokenUtil.java
+++ b/back/src/main/java/com/duder/api/security/util/JwtTokenUtil.java
@@ -64,8 +64,8 @@ public class JwtTokenUtil {
 
     // Jwt 토큰 -> 인증 정보 조회
     public Authentication getAuthentication(String token){
-        String kakaoId = getPayload(token);
-        Member member = memberRepository.findByProviderId(kakaoId).orElseThrow(
+        String providerId = getPayload(token);
+        Member member = memberRepository.findByProviderId(providerId).orElseThrow(
                 () -> new AuthenticationCredentialsNotFoundException("존재하지 않는 회원입니다.")
         );
 
@@ -73,11 +73,11 @@ public class JwtTokenUtil {
 
         OAuth2User defaultUser = new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(null)),
-                attribute, "kakaoId");
+                attribute, "providerId");
 
         return new OAuth2AuthenticationToken(defaultUser,
                 Collections.singleton(new SimpleGrantedAuthority(null)),
-                "kakao");
+                "provider");
     }
 
     public Map<String, Object> createAttribute(Member member){

--- a/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
@@ -1,144 +1,101 @@
 package com.duder.api.post.service;
 
-import com.duder.api.member.domain.Member;
 import com.duder.api.member.domain.MemberRepository;
-import com.duder.api.post.domain.Photo;
-import com.duder.api.post.domain.Post;
 import com.duder.api.post.domain.PostRepository;
-import com.duder.api.post.request.PostEnrollRequest;
 import com.duder.api.post.response.PostResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.annotation.PostConstruct;
-import javax.persistence.EntityManager;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+import static com.duder.api.fixture.MemberFixture.*;
+import static com.duder.api.fixture.PostFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class PostServiceTest {
 
-    @Autowired MemberRepository memberRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired PostService postService;
-    public Member memberA;
+    private PostService postService;
 
-    @Autowired EntityManager em;
+    @Mock
+    private MemberRepository memberRepository;
 
-    @PostConstruct
+    @Mock
+    private PostRepository postRepository;
+
+    @BeforeEach
     public void init(){
-        memberA = new Member("memeber1", "nick",
-                "www.abc.com", "www.naver.com");
-        memberRepository.save(memberA);
+        postService = new PostService(postRepository);
     }
 
-    @DisplayName("1. 게시글 등록 테스트: 전송 url이 하나일 때")
+    @DisplayName("1. 게시글 등록 테스트")
     @Test
     public void enroll_1() throws Exception {
-        //given
-        PostEnrollRequest request = new  PostEnrollRequest(37.2323, 126.2323,
-                Arrays.asList("www.abd.com"), "게시글");
+        when(postRepository.save(any())).thenReturn(POST1);
 
-        //when
-        Long postId = postService.enroll(memberA, request);
-        em.flush();
+        Long postId = postService.enroll(MEMBER1, 상수맛집_게시글_요청);
 
-        //then
-        Post post = findById(postId);
-
-        assertThat(post.getId()).isEqualTo(postId);
-        assertThat(post.getContent()).isEqualTo("게시글");
-        assertThat(post.getPhoto().getPhotoUrl()).contains("www.abd.com");
+        assertThat(postId).isEqualTo(POST1.getId());
     }
 
-    @DisplayName("2. 게시글 등록 테스트: 전송 url이 두개일 때")
-    @Test
-    public void enroll_2() throws Exception {
-        //given
-        PostEnrollRequest request = new PostEnrollRequest(37.2323, 126.2323,
-                Arrays.asList("www.abc.com", "www.abd.com"), "게시글");
-
-        //when
-        Long postId = postService.enroll(memberA, request);
-
-        //then
-        Post post = findById(postId);
-
-        assertThat(post.getId()).isEqualTo(postId);
-        assertThat(post.getContent()).isEqualTo("게시글");
-        assertThat(post.getPhoto().getPhotoUrl()).contains("www.abc.com", "www.abd.com");
-    }
-
-    @DisplayName("3. 게시글 조회 테스트: 한 개 조회")
+    @DisplayName("2. 게시글 조회 테스트")
     @Test
     public void findPostById() throws Exception{
-        //given
-        Post post = postRepository.save(new Post(37.2323, 126.2323,
-                new Photo(Arrays.asList("www.abc.com")), "게시글", memberA, 1));
-        em.flush();
+        Long postId = 1L;
+        when(postRepository.findPostById(postId)).thenReturn(Optional.of(POST1));
 
-        //when
-        PostResponse findPost = postService.findPostById(post.getId());
+        postService.updatePost(postId, 게시글_수정_요청);
 
-        //then
-
-        assertThat(findPost.getId()).isEqualTo(post.getId());
+        assertThat(POST1.getContent()).isEqualTo(게시글_수정_요청.getContent());
     }
 
-
-    @DisplayName("4. 게시글 조회 테스트: 여러 게시글 조회-1")
+    @DisplayName("3. 게시글 조회 테스트: 주변 게시글 조회")
     @Test
     public void findPostAll() throws Exception{
         //given
-        int cellValue = CoordinateUtil.findCellValue(37.2323, 126.2323);
-        int cellValue1 = CoordinateUtil.findCellValue(37.2322, 126.2325);
-        int cellValue2 = CoordinateUtil.findCellValue(37.2324, 126.2321);
-        Post post1 = new Post(37.2323, 126.2323, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue);
-        Post post2 = new Post(37.2322, 126.2325, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue1);
-        Post post3 = new Post(37.2324, 126.2321, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue2);
+        when(postRepository.findByCellValues(any()))
+                .thenReturn(Arrays.asList(POST1, POST2, POST3));
 
         //when
-        postRepository.saveAll(Arrays.asList(post1, post2, post3));
-        List<PostResponse> allPosts = postService.findPostsByDistance(37.2323, 126.2323, 10);
+        List<PostResponse> responses = postService.findPostsByDistance(POST1.getLatitude(), POST1.getLongitude(), 10);
 
         //then
-        assertThat(allPosts.size()).isEqualTo(3);
+        assertThat(responses.size()).isEqualTo(3);
     }
 
-    @DisplayName("5. 게시글 조회 테스트: 여러 게시글 조회-2")
+    @DisplayName("4. 게시글 삭제 테스트 ")
     @Test
-    public void findPostAll2() throws Exception{
+    public void postDelete(){
         //given
-        int cellValue = CoordinateUtil.findCellValue(37.2323, 126.2323);
-        int cellValue1 = CoordinateUtil.findCellValue(37.2322, 126.2325);
-        int cellValue2 = CoordinateUtil.findCellValue(37.2324, 126.2321);
-        Post post1 = new Post(37.2323, 126.2323, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue);
-        Post post2 = new Post(37.2322, 126.2325, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue1);
-        Post post3 = new Post(37.2324, 126.2321, new Photo(Arrays.asList("www.abc.com")),
-                "게시글", memberA, cellValue2);
+        when(postRepository.findPostById(POST1.getId())).thenReturn(Optional.of(POST1));
 
         //when
-        postRepository.saveAll(Arrays.asList(post1, post2, post3));
-        List<PostResponse> allPosts = postService.findPostsByDistance(37.2323, 126.2323, 10);
+        postService.deletePost(MEMBER1, POST1.getId());
 
         //then
-        assertThat(allPosts.size()).isEqualTo(3);
+        verify(postRepository).delete(POST1);
     }
 
-    public Post findById(Long id) throws IllegalArgumentException {
-        return postRepository.findById(id).orElseThrow(() -> new IllegalArgumentException(id + "번은 존재하지 않는 post 입니다"));
+    @DisplayName("5. 게시물 업데이트 테스트")
+    @Test
+    public void postUpdate(){
+        //given
+        when(postRepository.findPostById(any())).thenReturn(Optional.of(POST1));
+
+        //when
+        postService.updatePost(1L, 게시글_수정_요청);
+
+        //then
+        assertThat(POST1.getContent()).isEqualTo(게시글_수정_요청.getContent());
     }
 
 }


### PR DESCRIPTION
1ea9ce8

- 테스트를 위한 객체 생성 (Mockito에 쓰이는 객체)

cba250f, 5a5e163, 04300d0 (#5)

- 게시글 API 개발 ( 한 게시글 조회, 본인 주변 distance 줘서 반환, 게시글 삭제, 게시글 수정)
- 게시글 관련 테스트 코드 작성


4278523 (#10)

- 사용자 관련 API ( 사용자 닉네임, 이메일 등 반환 및 사용자 닉네임 수정(PUT)