### PR TITLE
[BACK] 게시글 관련 서비스 로직 변경 및 인덱스 생성

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
-//	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/back/src/main/java/com/duder/api/fixture/PostFixture.java
+++ b/back/src/main/java/com/duder/api/fixture/PostFixture.java
@@ -14,16 +14,16 @@ public class PostFixture {
     public static final Long MEMBER_ID = 1L;
 
     public final static Post POST1 = new Post(POST_ID, 37.1234, 126.1234, Photo.of("www.abc.com", "www.def.com"),
-           "title1", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.1234, 126.1234));
+           "title1", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellCoordinate(37.1234, 126.1234));
 
     public final static Post POST2 = new Post(2L, 37.3456, 126.1324, Photo.of("www.abc.com", "www.def.com"),
-            "title2", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.3456, 126.1324));
+            "title2", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellCoordinate(37.3456, 126.1324));
 
     public final static Post POST3 = new Post(3L, 37.4567, 126.2345, Photo.of("www.abc.com", "www.def.com"),
-            "title3", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellValue(37.4567, 126.2345));
+            "title3", "content1", MemberFixture.MEMBER1, CoordinateUtil.findCellCoordinate(37.4567, 126.2345));
 
     public final static PostEnrollRequest 상수맛집_게시글_요청 = new PostEnrollRequest(37.1234, 126.1234,
-            Arrays.asList("www.abc.com", "www.def.com"), "상수맛집 추천좀요");
+            Arrays.asList("www.abc.com", "www.def.com"), "상수 맛집", "상수맛집 추천좀요");
 
     public final static PostUpdateRequest 게시글_수정_요청 = new PostUpdateRequest("title update", "상수 맛집 추천좀");
 

--- a/back/src/main/java/com/duder/api/member/domain/Member.java
+++ b/back/src/main/java/com/duder/api/member/domain/Member.java
@@ -19,6 +19,7 @@ import javax.persistence.*;
 
  @Getter @NoArgsConstructor
  @Entity
+ @Table(indexes = {@Index(name = "i_member", columnList = "providerId")})
 public class Member extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/back/src/main/java/com/duder/api/post/domain/Post.java
+++ b/back/src/main/java/com/duder/api/post/domain/Post.java
@@ -3,6 +3,8 @@ package com.duder.api.post.domain;
 import com.duder.api.common.BaseEntity;
 import com.duder.api.member.domain.Member;
 import com.duder.api.post.request.PostUpdateRequest;
+import com.duder.api.post.service.Coordinate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +24,11 @@ import javax.persistence.*;
 
  @Getter
  @NoArgsConstructor
+ @AllArgsConstructor
  @Entity
+ @Table(
+         indexes = {@Index(name = "postMultiIndex", columnList = "compressedRow, compressedColumn")}
+ )
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,26 +52,21 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private Integer cellValue;
+    private Integer compressedRow;
 
-    public Post(double latitude, double longitude, Photo photo, String content, Member member, Integer cellValue) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.photo = photo;
-        this.content = content;
-        this.member = member;
-        this.cellValue = cellValue;
+    private Integer compressedColumn;
+
+
+    public Post(double latitude, double longitude, Photo photo, String title, String content, Member member, Integer compressedRow, Integer compressedColumn) {
+        this(null, latitude, longitude, photo, title, content, 0, member, compressedRow, compressedColumn);
     }
 
-    public Post(Long id, double latitude, double longitude, Photo photo, String title, String content, Member member, Integer cellValue) {
-        this.id = id;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.photo = photo;
-        this.title = title;
-        this.content = content;
-        this.member = member;
-        this.cellValue = cellValue;
+    public Post(Long id, double latitude, double longitude, Photo photo, String title, String content, Member member, Coordinate coordinate) {
+        this(id, latitude, longitude, photo, title, content, 0, member, coordinate.getRow(), coordinate.getColumn());
+    }
+
+    public Post(double latitude, double longitude, Photo photo, String title, String content, Member member, Coordinate coordinate) {
+        this(null, latitude, longitude, photo, title, content, 0, member, coordinate.getRow(), coordinate.getColumn());
     }
 
     public void update(PostUpdateRequest postUpdateRequest){

--- a/back/src/main/java/com/duder/api/post/domain/PostRepository.java
+++ b/back/src/main/java/com/duder/api/post/domain/PostRepository.java
@@ -10,6 +10,12 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findPostById(Long id);
 
-    @Query("select P from Post P where P.cellValue in (:cellValues)")
+//    @Query("select P from Post P where P.cellValue in (:cellValues)")
+    @Query("select P from Post P")
     List<Post> findByCellValues(@Param("cellValues") List<Integer> cellValues);
+
+    @Query("select P from Post P where (P.compressedRow between :rowStart and :rowEnd) and " +
+            "(P.compressedColumn between :columnStart and :columnEnd)")
+    List<Post> findCellByRange(@Param("rowStart") Integer rowStart, @Param("rowEnd") Integer rowEnd,
+                    @Param("columnStart") Integer columnStart, @Param("columnEnd") Integer columnEnd);
 }

--- a/back/src/main/java/com/duder/api/post/request/PostEnrollRequest.java
+++ b/back/src/main/java/com/duder/api/post/request/PostEnrollRequest.java
@@ -3,6 +3,7 @@ package com.duder.api.post.request;
 import com.duder.api.member.domain.Member;
 import com.duder.api.post.domain.Photo;
 import com.duder.api.post.domain.Post;
+import com.duder.api.post.service.Coordinate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,10 +17,11 @@ public class PostEnrollRequest {
     private double latitude;
     private double longitude;
     private List<String> photoUrls;
+    private String title;
     private String content;
 
-    public Post toPostWithMemberAndCell(Member member, Integer cellValue){
-        return new Post(latitude, longitude, new Photo(photoUrls), content, member, cellValue);
+    public Post toPostWithMemberAndCell(Member member, Coordinate coordinate){
+        return new Post(latitude, longitude, new Photo(photoUrls), title, content, member, coordinate);
     }
 
 }

--- a/back/src/main/java/com/duder/api/post/service/Coordinate.java
+++ b/back/src/main/java/com/duder/api/post/service/Coordinate.java
@@ -1,0 +1,13 @@
+package com.duder.api.post.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Coordinate {
+    private Integer row;
+    private Integer column;
+}

--- a/back/src/main/java/com/duder/api/post/service/CoordinateUtil.java
+++ b/back/src/main/java/com/duder/api/post/service/CoordinateUtil.java
@@ -2,6 +2,7 @@ package com.duder.api.post.service;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class CoordinateUtil {
@@ -116,6 +117,21 @@ public class CoordinateUtil {
         int row = calculateLength(UPPER_LEFT_LATITUDE, latitude, ONE_HUNDRED_METER_LATITUDE);
         int column = calculateLength(UPPER_LEFT_LONGITUDE, longitude, ONE_HUNDRED_METER_LONGITUDE);
         return LONGITUDE_LENGTH * row + column;
+    }
+
+    public static Coordinate findCellCoordinate(double latitude, double longitude) throws IllegalArgumentException {
+        validateCoordinate(latitude, longitude);
+        int row = calculateLength(UPPER_LEFT_LATITUDE, latitude, ONE_HUNDRED_METER_LATITUDE);
+        int column = calculateLength(UPPER_LEFT_LONGITUDE, longitude, ONE_HUNDRED_METER_LONGITUDE);
+        return new Coordinate(row, column);
+    }
+
+    public static List<Coordinate> findCellCoordinateInRange(double latitude, double longitude, int range) throws IllegalArgumentException {
+        Coordinate coordinate = findCellCoordinate(latitude, longitude);
+        Integer row = coordinate.getRow();
+        Integer column = coordinate.getColumn();
+        return Arrays.asList(new Coordinate(Math.max(row-range,0), Math.max(column-range, 0)),
+                new Coordinate(Math.min(row+range, LONGITUDE_LENGTH), Math.min(column+range, LATITUDE_LENGTH)));
     }
 
     public static List<Integer> findCellValueInRange(int cellId, int range) {

--- a/back/src/main/java/com/duder/api/post/service/PostService.java
+++ b/back/src/main/java/com/duder/api/post/service/PostService.java
@@ -28,9 +28,9 @@ public class PostService {
         double latitude = request.getLatitude();
         double longitude = request.getLongitude();
 
-        int cellValue = CoordinateUtil.findCellValue(latitude, longitude);
+        Coordinate coordinate = CoordinateUtil.findCellCoordinate(latitude, longitude);
 
-        return postRepository.save(request.toPostWithMemberAndCell(member, cellValue)).getId();
+        return postRepository.save(request.toPostWithMemberAndCell(member, coordinate)).getId();
     }
 
     public PostResponse findPostById (Long postId) throws IllegalArgumentException {
@@ -40,11 +40,13 @@ public class PostService {
     // parameter : 현재 위치(latitude, longitude) 주변 거리 (distance)
     public List<PostResponse> findPostsByDistance (double latitude, double longitude, int distance)
                                                                         throws IllegalArgumentException{
-        int userCellValue = CoordinateUtil.findCellValue(latitude, longitude);
-        List<Integer> allCellValue = CoordinateUtil.findCellValueInRange(userCellValue, distance);
-        // 쿼리 날림
+        List<Coordinate> coordinates = CoordinateUtil.findCellCoordinateInRange(latitude, longitude, distance);
+        Coordinate leftUpCoordinate = coordinates.get(0);
+        Coordinate rightDownCoordinate = coordinates.get(1);
 
-        return postRepository.findByCellValues(allCellValue)
+        // 쿼리 날림
+        return postRepository.findCellByRange(leftUpCoordinate.getRow(), rightDownCoordinate.getRow(),
+                        leftUpCoordinate.getColumn(), rightDownCoordinate.getColumn())
                 .stream()
                 .map(PostResponse::new)
                 .collect(Collectors.toList());

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -7,11 +7,17 @@ spring:
     console:
       enabled: true
 
+#  datasource:
+#    url: jdbc:h2:mem:duder # /h2-console 에서 이 주소로 들어가면 됨
+#    username: sa
+#    password:
+#    driver-class-name: org.h2.Driver
   datasource:
-    url: jdbc:h2:mem:duder # /h2-console 에서 이 주소로 들어가면 됨
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    hikari:
+      jdbc-url: jdbc:mysql://localhost:3306/duder?serverTimezone=UTC&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: rla123
 
   jpa:
     hibernate:

--- a/back/src/test/java/com/duder/api/post/service/CoordinateUtilTest.java
+++ b/back/src/test/java/com/duder/api/post/service/CoordinateUtilTest.java
@@ -138,4 +138,28 @@ class CoordinateUtilTest {
                 cellValue + LONGITUDE_LENGTH * 10, cellValue - LONGITUDE_LENGTH * 10);
     }
 
+    @DisplayName("위치 중심으로 range 만큼 좌표 범위 구하기")
+    @Test
+    public void cell(){
+        int range = 10;
+        List<Coordinate> rangeValue = findCellCoordinateInRange(homeLat, homeLong, range);
+
+        assertThat(rangeValue.get(1).getRow() - rangeValue.get(0).getRow()).isEqualTo(2 * range);
+        assertThat(rangeValue.get(1).getColumn() - rangeValue.get(0).getColumn()).isEqualTo(2 * range);
+    }
+
+    @DisplayName("좌표 기준으로 coordiate가 잘 반환 되는지 테스트")
+    @Test
+    public void cell2(){
+        Coordinate coordiateHome = findCellCoordinate(homeLat, homeLong);
+        Coordinate far300M = findCellCoordinate(homeLat + ONE_HUNDRED_METER_LATITUDE * 3, homeLong + ONE_HUNDRED_METER_LONGITUDE * 3);
+
+
+        // 위도는 클 수록 row가 작음
+        assertThat(coordiateHome.getRow()).isGreaterThan(far300M.getRow());
+
+        // 경도는 클 수록 column이 큼
+        assertThat(coordiateHome.getColumn()).isLessThan(far300M.getColumn());
+    }
+
 }

--- a/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
@@ -62,7 +62,7 @@ class PostServiceTest {
     @Test
     public void findPostAll() throws Exception{
         //given
-        when(postRepository.findByCellValues(any()))
+        when(postRepository.findCellByRange(any(), any(), any(), any()))
                 .thenReturn(Arrays.asList(POST1, POST2, POST3));
 
         //when


### PR DESCRIPTION

dc78715
- 주로 회원 로그인 시 검증할 때 providerId로 많이 조회를 하기 때문에 그 부분 인덱스 추가

ef53e6d, 7784293
- 기존에는 cellValue로 해당 게시글을 저장했지만 row, column으로 범위질의 하는 것이 더 맞다 판단하여
- (row, column) 으로 멀티 인덱스를 구성하여 로직 수정


17c3b2b
- 테스트 관련 fixture( 테스트로 쓰이는 객체나 요청 객체 등 ) 수정
