### PR TITLE
[Fix] 좋아요 요청 중복 저장 수정 및 api 스펙 추가

### DIFF
--- a/back/src/main/java/com/duder/api/favorite/application/FavoriteService.java
+++ b/back/src/main/java/com/duder/api/favorite/application/FavoriteService.java
@@ -18,11 +18,15 @@ public class FavoriteService {
 
     private static final String FAILED_NOT_FOUND_POST = "게시글이 존재하지 않거나 삭제되었습니다.";
     private static final String FAILED_NOT_FOUND_DATA = "해당 좋아요는 이미 삭제되었거나 중복되어 저장되어 있습니다.";
+    private static final String FAILED_NOT_DUPLICATE_DATA = "해당 중복되어 저장되어 있습니다.";
+
 
     @Transactional
     public Long push(Member member, Long postId) throws IllegalArgumentException{
-        Post post = findPostById(postId);
-        return favoriteRepository.save(new Favorite(member, post)).getId();
+        if (findFavorite(member.getId(), postId)){
+            throw new IllegalArgumentException(FAILED_NOT_DUPLICATE_DATA);
+        }
+        return favoriteRepository.save(new Favorite(member, new Post(postId))).getId();
     }
 
     @Transactional
@@ -35,9 +39,7 @@ public class FavoriteService {
         return favorite.getId();
     }
 
-    public Post findPostById(Long postId){
-        return postRepository.findPostById(postId).orElseThrow(
-                () -> new IllegalArgumentException(FAILED_NOT_FOUND_POST)
-        );
+    public boolean findFavorite(Long memberId, Long postId){
+        return favoriteRepository.findFavoriteByMemberIdAndPostId(memberId, postId).isPresent();
     }
 }

--- a/back/src/main/java/com/duder/api/fixture/FavoriteFixture.java
+++ b/back/src/main/java/com/duder/api/fixture/FavoriteFixture.java
@@ -1,0 +1,10 @@
+package com.duder.api.fixture;
+
+import com.duder.api.favorite.domain.Favorite;
+
+import static com.duder.api.fixture.MemberFixture.MEMBER1;
+import static com.duder.api.fixture.PostFixture.POST1;
+
+public class FavoriteFixture {
+    public static Favorite FAVORITE1 = new Favorite(1L, MEMBER1, POST1);
+}

--- a/back/src/main/java/com/duder/api/post/domain/PostRepository.java
+++ b/back/src/main/java/com/duder/api/post/domain/PostRepository.java
@@ -14,8 +14,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("select P from Post P")
     List<Post> findByCellValues(@Param("cellValues") List<Integer> cellValues);
 
-    @Query("select P from Post P where (P.compressedRow between :rowStart and :rowEnd) and " +
-            "(P.compressedColumn between :columnStart and :columnEnd)")
+    @Query("select P from Post P join fetch P.member where (P.compressedRow between :rowStart and :rowEnd) and " +
+            "(P.compressedColumn between :columnStart and :columnEnd) order by P.createdAt DESC")
     List<Post> findCellByRange(@Param("rowStart") Integer rowStart, @Param("rowEnd") Integer rowEnd,
                     @Param("columnStart") Integer columnStart, @Param("columnEnd") Integer columnEnd);
 

--- a/back/src/main/java/com/duder/api/post/presentation/PostController.java
+++ b/back/src/main/java/com/duder/api/post/presentation/PostController.java
@@ -59,7 +59,17 @@ public class PostController {
     public ApiForm<?> findPostsByDistance(@RequestParam("latitude") double latitude, @RequestParam("longitude") double longitude,
                                           @RequestParam("distance") int distance){
         try{
-            return succeed(postService.findPostsByDistance(latitude, longitude, distance), SUCCESS_FIND_POST);
+            return succeed(postService.findPostsOrderByCreatedAt(latitude, longitude, distance), SUCCESS_FIND_POST);
+        }catch (IllegalArgumentException e){
+            return fail(e.getMessage());
+        }
+    }
+
+    @GetMapping("/get/hot")
+    public ApiForm<?> findPostsByDistanceOrderByFavorite(@RequestParam("latitude") double latitude, @RequestParam("longitude") double longitude,
+                                          @RequestParam("distance") int distance){
+        try{
+            return succeed(postService.findPostsOrderByFavorite(latitude, longitude, distance), SUCCESS_FIND_POST);
         }catch (IllegalArgumentException e){
             return fail(e.getMessage());
         }

--- a/back/src/main/java/com/duder/api/post/presentation/PostController.java
+++ b/back/src/main/java/com/duder/api/post/presentation/PostController.java
@@ -37,9 +37,9 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public ApiForm<?> findPostById(@PathVariable Long postId) {
+    public ApiForm<?> findPostById(@AuthenticationPrincipal OAuth2User oAuth2User, @PathVariable Long postId) {
         try {
-            return succeed(postService.findPostById(postId), SUCCESS_FIND_POST);
+            return succeed(postService.findPostById(oAuth2User.getAttribute("member"), postId), SUCCESS_FIND_POST);
         }catch (IllegalArgumentException e){
             return fail(e.getMessage());
         }

--- a/back/src/main/java/com/duder/api/post/response/PostListResponse.java
+++ b/back/src/main/java/com/duder/api/post/response/PostListResponse.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class PostResponse {
+public class PostListResponse {
     private Long id;
     private double latitude;
     private double longitude;
@@ -26,11 +26,11 @@ public class PostResponse {
     private long commentCount = 0;
     private double distance = 0.0;
 
-    public static PostResponse of(Post post){
-        return new PostResponse(post);
+    public static PostListResponse of(Post post){
+        return new PostListResponse(post);
     }
 
-    public PostResponse (Post post){
+    public PostListResponse(Post post){
         this.id = post.getId();
         this.latitude = post.getLatitude();
         this.longitude = post.getLongitude();
@@ -39,7 +39,7 @@ public class PostResponse {
         this.member = MemberResponse.of(post.getMember());
     }
 
-    public PostResponse (Post post, double latitude, double longitude, long favoriteCount, long commentCount){
+    public PostListResponse(Post post, double latitude, double longitude, long favoriteCount, long commentCount){
         this.id = post.getId();
         this.latitude = post.getLatitude();
         this.longitude = post.getLongitude();
@@ -52,9 +52,9 @@ public class PostResponse {
         this.commentCount = commentCount;
     }
 
-    public static List<PostResponse> toList(List<Post> posts, Map<Long, Long> favoriteOfPosts, Map<Long, Long> commentOfPosts, double latitude, double longitude) {
+    public static List<PostListResponse> toList(List<Post> posts, Map<Long, Long> favoriteOfPosts, Map<Long, Long> commentOfPosts, double latitude, double longitude) {
         return posts.stream()
-                .map(o-> new PostResponse(o, latitude, longitude, favoriteOfPosts.get(o.getId()), commentOfPosts.get(o.getId())))
+                .map(o-> new PostListResponse(o, latitude, longitude, favoriteOfPosts.get(o.getId()), commentOfPosts.get(o.getId())))
                 .collect(Collectors.toList());
     }
 }

--- a/back/src/main/java/com/duder/api/post/response/PostWithCommentResponse.java
+++ b/back/src/main/java/com/duder/api/post/response/PostWithCommentResponse.java
@@ -19,8 +19,10 @@ public class PostWithCommentResponse {
     private Long id;
     private double latitude;
     private double longitude;
+    private List<String> photoUrls = new ArrayList<>();
     private String content;
     private long view;
+    private boolean favoriteState;
     private MemberResponse member;
 
     private List<AllCommentResponse> comments = new ArrayList<>();
@@ -28,16 +30,18 @@ public class PostWithCommentResponse {
     private int favoriteCount = 0;
     private int commentCount = 0;
 
-    public static PostWithCommentResponse of(Post post, List<AllCommentResponse> comments){
-        return new PostWithCommentResponse(post, comments);
+    public static PostWithCommentResponse of(Post post, List<AllCommentResponse> comments, boolean favoriteState){
+        return new PostWithCommentResponse(post, comments, favoriteState);
     }
 
-    public PostWithCommentResponse (Post post, List<AllCommentResponse> comments){
+    public PostWithCommentResponse (Post post, List<AllCommentResponse> comments, boolean favoriteState){
         this.id = post.getId();
         this.latitude = post.getLatitude();
         this.longitude = post.getLongitude();
+        this.photoUrls = post.getPhoto().getPhotoUrl();
         this.content = post.getContent();
         this.view = 0;
+        this.favoriteState = favoriteState;
         this.member = MemberResponse.of(post.getMember());
         this.comments = comments;
     }

--- a/back/src/main/java/com/duder/api/post/service/PostService.java
+++ b/back/src/main/java/com/duder/api/post/service/PostService.java
@@ -3,7 +3,6 @@ package com.duder.api.post.service;
 import com.duder.api.comment.application.CommentService;
 import com.duder.api.comment.domain.CommentCountDto;
 import com.duder.api.comment.domain.CommentRepository;
-import com.duder.api.favorite.domain.Favorite;
 import com.duder.api.favorite.domain.FavoriteCountDto;
 import com.duder.api.favorite.domain.FavoriteRepository;
 import com.duder.api.member.domain.Member;
@@ -11,7 +10,7 @@ import com.duder.api.post.domain.Post;
 import com.duder.api.post.domain.PostRepository;
 import com.duder.api.post.request.PostEnrollRequest;
 import com.duder.api.post.request.PostUpdateRequest;
-import com.duder.api.post.response.PostResponse;
+import com.duder.api.post.response.PostListResponse;
 import com.duder.api.post.response.PostWithCommentResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,26 +47,12 @@ public class PostService {
         return postRepository.save(request.toPostWithMemberAndCell(member, coordinate)).getId();
     }
 
-    public PostWithCommentResponse findPostById (Long postId) throws IllegalArgumentException {
-        return PostWithCommentResponse.of(findById(postId), commentService.getCommentByPostId(postId));
+    public PostWithCommentResponse findPostById (Member member, Long postId) throws IllegalArgumentException {
+        return PostWithCommentResponse.of(findById(postId), commentService.getCommentByPostId(postId),
+                checkFavorite(member.getId(), postId));
     }
 
-    // parameter : 현재 위치(latitude, longitude) 주변 거리 (distance)
-    public List<PostResponse> findPostsByDistance2 (double latitude, double longitude, int distance)
-                                                                        throws IllegalArgumentException{
-        List<Coordinate> coordinates = CoordinateUtil.findCellCoordinateInRange(latitude, longitude, distance);
-        Coordinate leftUpCoordinate = coordinates.get(0);
-        Coordinate rightDownCoordinate = coordinates.get(1);
-
-        // 쿼리 날림
-        return postRepository.findCellByRange(leftUpCoordinate.getRow(), rightDownCoordinate.getRow(),
-                        leftUpCoordinate.getColumn(), rightDownCoordinate.getColumn())
-                .stream()
-                .map((o) -> new PostResponse(o, latitude, longitude, 1,0))
-                .collect(Collectors.toList());
-    }
-
-    public List<PostResponse> findPostsByDistance (double latitude, double longitude, int distance)
+    public List<PostListResponse> findPostsByDistance (double latitude, double longitude, int distance)
             throws IllegalArgumentException{
         List<Coordinate> coordinates = CoordinateUtil.findCellCoordinateInRange(latitude, longitude, distance);
         Coordinate leftUpCoordinate = coordinates.get(0);
@@ -83,23 +68,23 @@ public class PostService {
         Map<Long, Long> commentOfPosts = commentRepository.findCommentCount(posts)
                 .stream().collect(toMap(CommentCountDto::getCommentId, CommentCountDto::getCommentCount));
 
-        return PostResponse.toList(posts, fillZero(favoriteOfPosts, posts),
+        return PostListResponse.toList(posts, fillZero(favoriteOfPosts, posts),
                 fillZero(commentOfPosts, posts), latitude, longitude);
     }
 
 
-    public List<PostResponse> findPostByMember(Member member){
+    public List<PostListResponse> findPostByMember(Member member){
         return postRepository.findPostByMemberId(member.getId())
                 .stream()
-                .map(PostResponse::new)
+                .map(PostListResponse::new)
                 .collect(Collectors.toList());
     }
 
     @Transactional
-    public PostResponse updatePost (Long postId, PostUpdateRequest postUpdateRequest) throws IllegalArgumentException{
+    public PostListResponse updatePost (Long postId, PostUpdateRequest postUpdateRequest) throws IllegalArgumentException{
         Post post = findById(postId);
         post.update(postUpdateRequest);
-        return PostResponse.of(post);
+        return PostListResponse.of(post);
     }
 
     @Transactional
@@ -116,6 +101,10 @@ public class PostService {
         return postRepository.findPostById(postId).orElseThrow(
                 () -> new IllegalArgumentException("해당 게시글이 존재하지 않습니다.")
         );
+    }
+
+    public boolean checkFavorite(Long memberId, Long postId){
+        return favoriteRepository.findFavoriteByMemberIdAndPostId(memberId, postId).isPresent();
     }
 
     public Map<Long, Long> fillZero(Map<Long, Long> countMap, List<Post> posts){

--- a/back/src/test/java/com/duder/api/favorite/application/FavoriteServiceTest.java
+++ b/back/src/test/java/com/duder/api/favorite/application/FavoriteServiceTest.java
@@ -1,8 +1,6 @@
 package com.duder.api.favorite.application;
 
-import com.duder.api.favorite.domain.Favorite;
 import com.duder.api.favorite.domain.FavoriteRepository;
-import com.duder.api.fixture.MemberFixture;
 import com.duder.api.post.domain.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +11,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static com.duder.api.fixture.FavoriteFixture.FAVORITE1;
 import static com.duder.api.fixture.MemberFixture.MEMBER1;
 import static com.duder.api.fixture.PostFixture.POST1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,18 +38,28 @@ class FavoriteServiceTest {
 
     @Test
     void favorite_post_test(){
-        when(postRepository.findPostById(any())).thenReturn(Optional.of(POST1));
-        when(favoriteRepository.save(any())).thenReturn(new Favorite(1L, MEMBER1, POST1));
+        when(favoriteRepository.findFavoriteByMemberIdAndPostId(any(), any()))
+                .thenReturn(Optional.empty());
+        when(favoriteRepository.save(any())).thenReturn(FAVORITE1);
         assertThat(favoriteService.push(MEMBER1, POST1.getId())).isEqualTo(POST1.getId());
+    }
+
+    @DisplayName("이미 좋아요가 저장되어 있을 때 오류")
+    @Test
+    void favorite_post_test2(){
+        when(favoriteRepository.findFavoriteByMemberIdAndPostId(any(), any()))
+                .thenReturn(Optional.of(FAVORITE1));
+
+        assertThatThrownBy(() -> favoriteService.push(MEMBER1, POST1.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void favorite_delete_test(){
-        Favorite favorite = new Favorite(1L, MEMBER1, POST1);
         when(favoriteRepository.findFavoriteByMemberIdAndPostId(MEMBER1.getId(), POST1.getId()))
-                .thenReturn(Optional.of(favorite));
+                .thenReturn(Optional.of(FAVORITE1));
         favoriteService.delete(MEMBER1, POST1.getId());
-        verify(favoriteRepository).delete(favorite);
+        verify(favoriteRepository).delete(FAVORITE1);
     }
 
 }

--- a/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
@@ -6,7 +6,7 @@ import com.duder.api.comment.domain.CommentRepository;
 import com.duder.api.favorite.domain.FavoriteCountDto;
 import com.duder.api.favorite.domain.FavoriteRepository;
 import com.duder.api.post.domain.PostRepository;
-import com.duder.api.post.response.PostResponse;
+import com.duder.api.post.response.PostListResponse;
 import com.duder.api.post.response.PostWithCommentResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -66,7 +66,7 @@ class PostServiceTest {
         when(postRepository.findPostById(postId)).thenReturn(Optional.of(POST1));
         when(commentService.getCommentByPostId(POST1.getId())).thenReturn(Arrays.asList(ALL_COMMENT1, ALL_COMMENT2));
 
-        PostWithCommentResponse response = postService.findPostById(postId);
+        PostWithCommentResponse response = postService.findPostById(MEMBER1, postId);
 
         assertThat(response.getComments().size()).isEqualTo(2);
         assertThat(response.getId()).isEqualTo(postId);
@@ -83,7 +83,7 @@ class PostServiceTest {
         when(favoriteRepository.findFavoriteCount(Arrays.asList(POST1, POST2, POST3)))
                 .thenReturn(Arrays.asList(new FavoriteCountDto(POST1.getId(), 1L)));
         //when
-        List<PostResponse> responses = postService.findPostsByDistance(POST1.getLatitude(), POST1.getLongitude(), 10);
+        List<PostListResponse> responses = postService.findPostsByDistance(POST1.getLatitude(), POST1.getLongitude(), 10);
 
         //then
         assertThat(responses.size()).isEqualTo(3);

--- a/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/duder/api/post/service/PostServiceTest.java
@@ -83,7 +83,7 @@ class PostServiceTest {
         when(favoriteRepository.findFavoriteCount(Arrays.asList(POST1, POST2, POST3)))
                 .thenReturn(Arrays.asList(new FavoriteCountDto(POST1.getId(), 1L)));
         //when
-        List<PostListResponse> responses = postService.findPostsByDistance(POST1.getLatitude(), POST1.getLongitude(), 10);
+        List<PostListResponse> responses = postService.findPostsOrderByCreatedAt(POST1.getLatitude(), POST1.getLongitude(), 10);
 
         //then
         assertThat(responses.size()).isEqualTo(3);


### PR DESCRIPTION
4e59b18e96f287857e9a9da239018e683d41a356

- 좋아요 요청 시 먼저 조회 한 뒤 중복을 검증함. 중복 시 -> 오류메세지와 함께 400 에러 반환

5f8010366528cb02743ef963785b4787ff72d79c

- 테스트를 위한 목 데이터 생성

fa7a3e61aaffbed0fcdf49311396500d90b104fa

- DTO 컬럼 추가 (사용자가 게시글을 조회 했을 때 자신이 좋아요를 등록한 게시글인지? 확인하는 컬럼)


cdf04c1, d7310a0

- 최신 게시글, 핫 게시글 조회 로직 추가 